### PR TITLE
feat: add router interface that supports both echo router and subrouters e.g. `Group`

### DIFF
--- a/jrpc.go
+++ b/jrpc.go
@@ -19,13 +19,17 @@ type JRPC interface {
 	Method(method string, handler HandlerFunc, middleware ...MiddlewareFunc)
 }
 
+type EchoRouter interface {
+	Add(method, path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route
+}
+
 type jrpc struct {
 	methods map[string]HandlerFunc
-	echo    *echo.Echo
+	echo    EchoRouter
 }
 
 // Endpoint create instance of jrpc route
-func Endpoint(e *echo.Echo, path string, m ...echo.MiddlewareFunc) JRPC {
+func Endpoint(e EchoRouter, path string, m ...echo.MiddlewareFunc) JRPC {
 	j := &jrpc{
 		methods: make(map[string]HandlerFunc),
 		echo:    e,

--- a/jrpc_test.go
+++ b/jrpc_test.go
@@ -56,6 +56,18 @@ func TestEmptyRequest(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code, "Empty request must return error 400 Bad Request")
 }
 
+func TestGroupRouter(t *testing.T) {
+
+	e := echo.New()
+	g := e.Group("/group")
+	Endpoint(g, "/jrpc")
+	req := httptest.NewRequest(http.MethodPost, "/group/jrpc", nil)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "Empty request must return error 400 Bad Request")
+}
+
 func TestHandler(t *testing.T) {
 	testCases := []struct {
 		when string


### PR DESCRIPTION
Goal is to also support [`*echo.Group`](https://echo.labstack.com/docs/routing#group).

The signature looks like a breaking change but `*echo.Echo` already implements this interface so it should not break for existing users.